### PR TITLE
Fix getFragment method

### DIFF
--- a/package/src/NodeHiveClient.js
+++ b/package/src/NodeHiveClient.js
@@ -239,7 +239,7 @@ export class NodeHiveClient {
 
 
         let queryString = "";
-        const type = "nodehive_fragment-" + fragmentType;
+        const type = "nodehive_fragment--" + fragmentType;
         const typeConfig = this.nodehiveconfig.entities[type];
 
         this.applyConfigToParams(params, typeConfig, type);


### PR DESCRIPTION
This pull request fixes a bug in the getFragment functionality that was causing the fetching of fragments to fail due to a typo.