### PR TITLE
feat(auth): OAuth 2.0 Authorization Code flow with PKCE

### DIFF
--- a/OAUTH_AUTHENTICATION.md
+++ b/OAUTH_AUTHENTICATION.md
@@ -6,10 +6,11 @@ NodeHive Client now supports OAuth 2.0 authentication alongside the existing JWT
 
 ### OAuth Grant Types
 
-The library supports two OAuth 2.0 grant types:
+The library supports three OAuth 2.0 grant types:
 
-1. **Password Grant** - For user authentication (default)
+1. **Password Grant** - For user authentication (default, deprecated by OAuth 2.1)
 2. **Client Credentials Grant** - For server-to-server / service account authentication
+3. **Authorization Code Grant with PKCE** - For SSO via an Identity Provider redirect (recommended for user authentication, OAuth 2.1 compliant)
 
 ### OAuth Password Grant (User Authentication)
 
@@ -93,6 +94,88 @@ const articles = await client.getNodes('article');
 - ✅ Faster authentication (fewer parameters)
 - ✅ Better for automated systems
 - ✅ Acts as service account, not specific user
+
+### OAuth Authorization Code Grant with PKCE (SSO)
+
+Use this grant for delegating user login to a central Identity Provider (Drupal acting as IdP). The user is redirected to the IdP's `/oauth/authorize` endpoint, signs in there once, and is redirected back to your application with an authorization code. Your application exchanges the code (plus a PKCE `code_verifier`) for an access token + refresh token. Subsequent visits to other frontends sharing the same IdP get silent SSO via the IdP's session cookie — no second password prompt.
+
+The client only ever sees the IdP's redirect URL; credentials never touch the frontend. This is the recommended flow per OAuth 2.1.
+
+**Setup the SDK with `grantType: 'authorization_code'`:**
+
+```javascript
+import {
+    NodeHiveClient,
+    generatePKCE,
+    generateState,
+    buildAuthorizeUrl
+} from 'nodehive-js';
+
+const client = new NodeHiveClient({
+    baseUrl: process.env.DRUPAL_BASE_URL, // resource server (REST calls)
+    auth: {
+        method: 'oauth',
+        oauth: {
+            grantType: 'authorization_code',
+            clientId: process.env.OAUTH_CLIENT_ID,
+            clientSecret: process.env.OAUTH_CLIENT_SECRET,
+            scope: 'frontend',
+            authorizeUrl: process.env.OAUTH_AUTHORIZE_URL, // e.g. https://idp/oauth/authorize
+            tokenUrl: process.env.OAUTH_TOKEN_URL          // optional, defaults to {baseUrl}/oauth/token
+        }
+    }
+});
+```
+
+**Login route — start the redirect:**
+
+```javascript
+// e.g. Next.js Route Handler at /api/auth/login
+const { codeVerifier, codeChallenge } = await generatePKCE();
+const state = generateState();
+
+// Persist codeVerifier + state in an httpOnly cookie (short TTL, e.g. 10 min).
+// The same value is required in the callback handler.
+
+const redirectUrl = buildAuthorizeUrl({
+    authorizeUrl: process.env.OAUTH_AUTHORIZE_URL,
+    clientId: process.env.OAUTH_CLIENT_ID,
+    redirectUri: `${origin}/api/auth/callback`,
+    scope: 'frontend',
+    state,
+    codeChallenge
+});
+// 302 redirect the user to redirectUrl
+```
+
+**Callback route — exchange the code for tokens:**
+
+```javascript
+// e.g. Next.js Route Handler at /api/auth/callback
+// Verify `state` matches the value stored in the cookie, then:
+
+const result = await client.auth.exchangeCode({
+    code: searchParams.get('code'),
+    codeVerifier: cookieCodeVerifier,
+    redirectUri: `${origin}/api/auth/callback`
+});
+
+// result.token, result.refresh_token, result.user are now persisted via the
+// configured storage adapter. The user's roles are available at
+// result.user.roles (same format as Password Grant).
+```
+
+**Refresh tokens (silent refresh):**
+
+```javascript
+// Trigger from middleware when access token nears expiry
+const refreshed = await client.auth.refreshToken();
+// refreshed.token and refreshed.refresh_token are rotated; user_details updated.
+```
+
+**Multi-domain deployments:** The `redirectUri` is supplied per call instead of statically configured, so the same deployment can serve multiple eTLD+1 hostnames. Register every callback URL in the OAuth client on the IdP.
+
+**Logout:** Call `client.logout()` to clear local credentials. For full revocation, POST the refresh token to the IdP's `/oauth/revoke` endpoint from your server.
 
 ### JWT Authentication (Legacy)
 

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 2.0.0-beta.13
+
+### Added
+
+- **OAuth 2.0 Authorization Code Flow with PKCE** (`grantType: 'authorization_code'`).
+  - New strategy `OAuthAuthorizationCodeStrategy` with `exchangeCode()` + `refreshToken()`.
+  - New helpers `generatePKCE()`, `generateState()`, `buildAuthorizeUrl()` (work in Node and browser via `crypto.subtle`).
+  - `OAuthConfig` gains `authorizeUrl`, `tokenUrl`, `redirectUri`.
+  - `AuthManager.exchangeCode()` delegate + `isAuthorizationCodeGrant()` predicate.
+  - Re-fetches `user_details` after every refresh so role changes propagate (same mechanic as Password Grant).
+
+### Changed
+
+- `fetchUserDetails(token)` extracted from `OAuthPasswordStrategy` into shared helper `src/auth/helpers/user-details.js`. Password and Authorization Code strategies now share the same implementation.
+
+### Tests
+
+- 8 new unit tests for PKCE, state generation, authorize URL building, AuthManager wiring, code exchange, refresh rotation, and error surfacing.

--- a/package/index.js
+++ b/package/index.js
@@ -13,8 +13,11 @@ import { BrowserStorage } from "./src/auth/storage/BrowserStorage.js";
 import { CookieStorage } from "./src/auth/storage/CookieStorage.js";
 import { ApiKeyStrategy } from "./src/auth/strategies/ApiKeyStrategy.js";
 import { JwtStrategy } from "./src/auth/strategies/JwtStrategy.js";
+import { OAuthAuthorizationCodeStrategy } from "./src/auth/strategies/OAuthAuthorizationCodeStrategy.js";
 import { OAuthClientCredentialsStrategy } from "./src/auth/strategies/OAuthClientCredentialsStrategy.js";
 import { OAuthPasswordStrategy } from "./src/auth/strategies/OAuthPasswordStrategy.js";
+import { generatePKCE, generateState } from "./src/auth/oauth/pkce.js";
+import { buildAuthorizeUrl } from "./src/auth/oauth/authorize-url.js";
 
 export {
   NodeHiveClient,
@@ -31,6 +34,11 @@ export {
   CookieStorage,
   ApiKeyStrategy,
   JwtStrategy,
+  OAuthAuthorizationCodeStrategy,
   OAuthClientCredentialsStrategy,
   OAuthPasswordStrategy,
+  // OAuth helpers (Authorization Code + PKCE)
+  generatePKCE,
+  generateState,
+  buildAuthorizeUrl,
 };

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodehive-js",
   "description": "Official JavaScript client library for NodeHive Headless CMS",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "type": "module",
   "main": "index.js",
   "types": "types.d.ts",

--- a/package/src/auth/AuthManager.js
+++ b/package/src/auth/AuthManager.js
@@ -2,6 +2,7 @@ import { ConfigurationError, AuthenticationError } from "../errors.js";
 import { MemoryStorage } from "./storage/MemoryStorage.js";
 import { ApiKeyStrategy } from "./strategies/ApiKeyStrategy.js";
 import { JwtStrategy } from "./strategies/JwtStrategy.js";
+import { OAuthAuthorizationCodeStrategy } from "./strategies/OAuthAuthorizationCodeStrategy.js";
 import { OAuthClientCredentialsStrategy } from "./strategies/OAuthClientCredentialsStrategy.js";
 import { OAuthPasswordStrategy } from "./strategies/OAuthPasswordStrategy.js";
 
@@ -116,6 +117,15 @@ export class AuthManager {
     return this.strategy.login(username, password, options);
   }
 
+  async exchangeCode(options = {}) {
+    if (typeof this.strategy.exchangeCode !== "function") {
+      throw new AuthenticationError(
+        "Current auth strategy does not support exchangeCode"
+      );
+    }
+    return this.strategy.exchangeCode(options);
+  }
+
   async refreshToken(options = {}) {
     return this.strategy.refreshToken(options);
   }
@@ -195,6 +205,13 @@ export class AuthManager {
     );
   }
 
+  isAuthorizationCodeGrant() {
+    return (
+      this.authMethod === "oauth" &&
+      this.oauthConfig.grantType === "authorization_code"
+    );
+  }
+
   resolveMaxAge(...candidates) {
     for (const ttl of candidates) {
       const numeric = Number(ttl);
@@ -210,9 +227,13 @@ export class AuthManager {
       case "jwt":
         return new JwtStrategy(this);
       case "oauth":
-        return this.isClientCredentialsGrant()
-          ? new OAuthClientCredentialsStrategy(this)
-          : new OAuthPasswordStrategy(this);
+        if (this.isClientCredentialsGrant()) {
+          return new OAuthClientCredentialsStrategy(this);
+        }
+        if (this.isAuthorizationCodeGrant()) {
+          return new OAuthAuthorizationCodeStrategy(this);
+        }
+        return new OAuthPasswordStrategy(this);
       default:
         throw new ConfigurationError(
           `Authentication method '${authMethod}' is not supported.`

--- a/package/src/auth/helpers/user-details.js
+++ b/package/src/auth/helpers/user-details.js
@@ -1,0 +1,37 @@
+import { AuthenticationError } from "../../errors.js";
+
+export async function fetchUserDetails(authManager, token) {
+  try {
+    const { client } = authManager;
+    const decodedJwt = authManager.decodeJwt(token);
+    const uid = decodedJwt?.sub;
+    if (!uid) {
+      throw new AuthenticationError("Invalid token structure");
+    }
+
+    const response = await fetch(
+      `${client.baseUrl}/user/${uid}?_format=json`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new AuthenticationError("OAuth user info fetch failed", {
+        status: response.status,
+      });
+    }
+
+    return await response.json();
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      throw error;
+    }
+    throw new AuthenticationError(
+      `Failed to fetch user details: ${error.message}`
+    );
+  }
+}

--- a/package/src/auth/oauth/authorize-url.js
+++ b/package/src/auth/oauth/authorize-url.js
@@ -1,0 +1,27 @@
+export function buildAuthorizeUrl({
+  authorizeUrl,
+  clientId,
+  redirectUri,
+  scope,
+  state,
+  codeChallenge,
+  codeChallengeMethod = "S256",
+}) {
+  if (!authorizeUrl) throw new Error("authorizeUrl is required");
+  if (!clientId) throw new Error("clientId is required");
+  if (!redirectUri) throw new Error("redirectUri is required");
+  if (!state) throw new Error("state is required");
+  if (!codeChallenge) throw new Error("codeChallenge is required");
+
+  const url = new URL(authorizeUrl);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", codeChallengeMethod);
+  if (scope) {
+    url.searchParams.set("scope", scope);
+  }
+  return url.toString();
+}

--- a/package/src/auth/oauth/pkce.js
+++ b/package/src/auth/oauth/pkce.js
@@ -1,0 +1,49 @@
+function base64UrlEncode(bytes) {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  const base64 = (typeof btoa === "function"
+    ? btoa(binary)
+    : Buffer.from(binary, "binary").toString("base64"));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function getCryptoSubtle() {
+  const cryptoObj =
+    (typeof globalThis !== "undefined" && globalThis.crypto) ||
+    (typeof window !== "undefined" && window.crypto);
+  if (!cryptoObj?.subtle) {
+    throw new Error(
+      "Web Crypto API not available — PKCE requires crypto.subtle (Node >= 16 or modern browser)"
+    );
+  }
+  return cryptoObj;
+}
+
+function getRandomBytes(length) {
+  const cryptoObj = getCryptoSubtle();
+  const bytes = new Uint8Array(length);
+  cryptoObj.getRandomValues(bytes);
+  return bytes;
+}
+
+export async function generatePKCE() {
+  const verifierBytes = getRandomBytes(32);
+  const codeVerifier = base64UrlEncode(verifierBytes);
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode(codeVerifier);
+  const digest = await getCryptoSubtle().subtle.digest("SHA-256", data);
+  const codeChallenge = base64UrlEncode(new Uint8Array(digest));
+
+  return {
+    codeVerifier,
+    codeChallenge,
+    codeChallengeMethod: "S256",
+  };
+}
+
+export function generateState() {
+  return base64UrlEncode(getRandomBytes(32));
+}

--- a/package/src/auth/strategies/OAuthAuthorizationCodeStrategy.js
+++ b/package/src/auth/strategies/OAuthAuthorizationCodeStrategy.js
@@ -1,0 +1,169 @@
+import { AuthenticationError } from "../../errors.js";
+import { fetchUserDetails } from "../helpers/user-details.js";
+
+export class OAuthAuthorizationCodeStrategy {
+  constructor(authManager) {
+    this.authManager = authManager;
+  }
+
+  async exchangeCode({ code, codeVerifier, redirectUri, ...options } = {}) {
+    if (!code) throw new AuthenticationError("Authorization code is required");
+    if (!codeVerifier) throw new AuthenticationError("Code verifier is required");
+
+    try {
+      const { client, oauthConfig } = this.authManager;
+      const clientId = options.clientId || oauthConfig.clientId;
+      const clientSecret = options.clientSecret || oauthConfig.clientSecret;
+      const effectiveRedirectUri = redirectUri || oauthConfig.redirectUri;
+
+      if (!effectiveRedirectUri) {
+        throw new AuthenticationError("Redirect URI is required");
+      }
+      if (!clientId || !clientSecret) {
+        throw new AuthenticationError("OAuth client credentials are required");
+      }
+
+      const tokenUrl =
+        oauthConfig.tokenUrl || `${client.baseUrl}/oauth/token`;
+
+      const params = new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: effectiveRedirectUri,
+        code_verifier: codeVerifier,
+      });
+
+      const response = await fetch(tokenUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: params.toString(),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new AuthenticationError(
+          errorData.error_description || "Authorization code exchange failed",
+          { status: response.status }
+        );
+      }
+
+      const data = await response.json();
+      return this._persistTokenResponse(data, options);
+    } catch (error) {
+      if (error instanceof AuthenticationError) {
+        throw error;
+      }
+      throw new AuthenticationError(
+        `OAuth authorization code exchange failed: ${error.message}`
+      );
+    }
+  }
+
+  async refreshToken(options = {}) {
+    try {
+      const { client, oauthConfig } = this.authManager;
+      const refreshToken = await this.authManager.getRefreshToken();
+      if (!refreshToken) {
+        throw new AuthenticationError("No refresh token available");
+      }
+
+      if (!oauthConfig.clientId || !oauthConfig.clientSecret) {
+        throw new AuthenticationError("OAuth client credentials are required");
+      }
+
+      const tokenUrl =
+        oauthConfig.tokenUrl || `${client.baseUrl}/oauth/token`;
+
+      const params = new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: oauthConfig.clientId,
+        client_secret: oauthConfig.clientSecret,
+        refresh_token: refreshToken,
+      });
+
+      const response = await fetch(tokenUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: params.toString(),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new AuthenticationError(
+          errorData.error_description || "Failed to refresh token",
+          { status: response.status }
+        );
+      }
+
+      const data = await response.json();
+      return this._persistTokenResponse(data, options);
+    } catch (error) {
+      if (error instanceof AuthenticationError) {
+        throw error;
+      }
+      throw new AuthenticationError(`Token refresh failed: ${error.message}`);
+    }
+  }
+
+  async fetchUserDetails(token) {
+    return fetchUserDetails(this.authManager, token);
+  }
+
+  async login() {
+    throw new AuthenticationError(
+      "Direct login is not supported for authorization_code grant — use exchangeCode() after redirect callback"
+    );
+  }
+
+  async _persistTokenResponse(data, options = {}) {
+    const session = this.authManager.session;
+    const maxAge = this.authManager.resolveMaxAge(
+      options?.tokenMaxAge,
+      session?.tokenMaxAge,
+      data?.expires_in
+    );
+    const tokenOptions = maxAge ? { maxAge } : undefined;
+
+    await this.authManager.setToken(data.access_token, tokenOptions);
+
+    if (data.refresh_token) {
+      const refreshTokenMaxAge = this.authManager.resolveMaxAge(
+        options?.refreshTokenMaxAge,
+        session?.refreshTokenMaxAge
+      );
+      const refreshTokenOptions = refreshTokenMaxAge
+        ? { maxAge: refreshTokenMaxAge }
+        : undefined;
+      await this.authManager.setRefreshToken(
+        data.refresh_token,
+        refreshTokenOptions
+      );
+    }
+
+    const expiresAt = maxAge ? Date.now() + maxAge * 1000 : null;
+    await this.authManager.setTokenExpiresAt(expiresAt, tokenOptions);
+
+    let userDetails = null;
+    try {
+      userDetails = await this.fetchUserDetails(data.access_token);
+      await this.authManager.setUserDetails(userDetails, tokenOptions);
+    } catch (error) {
+      console.error("Error fetching user details:", error);
+    }
+
+    return {
+      success: true,
+      token: data.access_token,
+      token_type: data.token_type,
+      refresh_token: data.refresh_token,
+      expires_in: maxAge ?? null,
+      user: userDetails,
+    };
+  }
+}

--- a/package/src/auth/strategies/OAuthPasswordStrategy.js
+++ b/package/src/auth/strategies/OAuthPasswordStrategy.js
@@ -1,4 +1,5 @@
 import { AuthenticationError } from "../../errors.js";
+import { fetchUserDetails } from "../helpers/user-details.js";
 
 export class OAuthPasswordStrategy {
   constructor(authManager) {
@@ -175,38 +176,6 @@ export class OAuthPasswordStrategy {
   }
 
   async fetchUserDetails(token) {
-    try {
-      const { client } = this.authManager;
-      const decodedJwt = this.authManager.decodeJwt(token);
-      const uid = decodedJwt?.sub;
-      if (!uid) {
-        throw new AuthenticationError("Invalid token structure");
-      }
-
-      const response = await fetch(
-        `${client.baseUrl}/user/${uid}?_format=json`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      if (!response.ok) {
-        throw new AuthenticationError("OAuth user info fetch failed", {
-          status: response.status,
-        });
-      }
-
-      return await response.json();
-    } catch (error) {
-      if (error instanceof AuthenticationError) {
-        throw error;
-      }
-      throw new AuthenticationError(
-        `Failed to fetch user details: ${error.message}`
-      );
-    }
+    return fetchUserDetails(this.authManager, token);
   }
 }

--- a/package/tests/auth.test.js
+++ b/package/tests/auth.test.js
@@ -5,7 +5,16 @@
  * Tests authentication, authorization, and session management
  */
 
-import { NodeHiveClient, AuthManager, MemoryStorage, BrowserStorage } from '../index.js';
+import {
+    NodeHiveClient,
+    AuthManager,
+    MemoryStorage,
+    BrowserStorage,
+    OAuthAuthorizationCodeStrategy,
+    generatePKCE,
+    generateState,
+    buildAuthorizeUrl
+} from '../index.js';
 import { TestHelper } from './test-helper.js';
 
 const helper = new TestHelper('Authentication Tests');
@@ -312,7 +321,304 @@ async function runTests() {
         helper.debug('Legacy methods still available');
     });
 
+    await helper.section('OAuth Authorization Code + PKCE');
+
+    await helper.test('generatePKCE returns S256 verifier/challenge pair', async () => {
+        const pair = await generatePKCE();
+        helper.assert(typeof pair.codeVerifier === 'string', 'codeVerifier is a string');
+        helper.assert(pair.codeVerifier.length >= 43, 'codeVerifier is base64url-encoded 32 random bytes');
+        helper.assert(typeof pair.codeChallenge === 'string', 'codeChallenge is a string');
+        helper.assert(pair.codeChallengeMethod === 'S256', 'codeChallengeMethod is S256');
+        helper.assert(/^[A-Za-z0-9_-]+$/.test(pair.codeVerifier), 'codeVerifier is base64url (no padding)');
+        helper.assert(/^[A-Za-z0-9_-]+$/.test(pair.codeChallenge), 'codeChallenge is base64url (no padding)');
+
+        // Roundtrip: SHA256(codeVerifier) -> base64url == codeChallenge
+        const { subtle } = globalThis.crypto;
+        const digest = await subtle.digest('SHA-256', new TextEncoder().encode(pair.codeVerifier));
+        const bytes = new Uint8Array(digest);
+        let binary = '';
+        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+        const expected = Buffer.from(binary, 'binary').toString('base64')
+            .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        helper.assert(expected === pair.codeChallenge, 'codeChallenge matches SHA256(codeVerifier)');
+        helper.debug('PKCE roundtrip verified');
+    });
+
+    await helper.test('generateState returns 32-byte base64url string', async () => {
+        const a = generateState();
+        const b = generateState();
+        helper.assert(typeof a === 'string', 'state is a string');
+        helper.assert(a.length >= 43, 'state has expected base64url length for 32 bytes');
+        helper.assert(/^[A-Za-z0-9_-]+$/.test(a), 'state is base64url (no padding)');
+        helper.assert(a !== b, 'consecutive states are random');
+        helper.debug('generateState produces unique base64url strings');
+    });
+
+    await helper.test('buildAuthorizeUrl builds expected query params', async () => {
+        const url = buildAuthorizeUrl({
+            authorizeUrl: 'https://idp.example.com/oauth/authorize',
+            clientId: 'frontends',
+            redirectUri: 'https://app.example.com/api/auth/callback',
+            scope: 'frontend',
+            state: 'STATE-123',
+            codeChallenge: 'CHALLENGE-xyz'
+        });
+        const parsed = new URL(url);
+        helper.assert(parsed.origin + parsed.pathname === 'https://idp.example.com/oauth/authorize', 'base URL preserved');
+        helper.assert(parsed.searchParams.get('response_type') === 'code', 'response_type=code');
+        helper.assert(parsed.searchParams.get('client_id') === 'frontends', 'client_id set');
+        helper.assert(parsed.searchParams.get('redirect_uri') === 'https://app.example.com/api/auth/callback', 'redirect_uri set');
+        helper.assert(parsed.searchParams.get('scope') === 'frontend', 'scope set');
+        helper.assert(parsed.searchParams.get('state') === 'STATE-123', 'state set');
+        helper.assert(parsed.searchParams.get('code_challenge') === 'CHALLENGE-xyz', 'code_challenge set');
+        helper.assert(parsed.searchParams.get('code_challenge_method') === 'S256', 'method=S256');
+        helper.debug('Authorize URL built correctly');
+    });
+
+    await helper.test('buildAuthorizeUrl validates required fields', async () => {
+        let threw = false;
+        try {
+            buildAuthorizeUrl({ clientId: 'x', redirectUri: 'y', state: 's', codeChallenge: 'c' });
+        } catch (e) {
+            threw = true;
+        }
+        helper.assert(threw, 'throws when authorizeUrl missing');
+        helper.debug('Missing fields rejected');
+    });
+
+    await helper.test('AuthManager wires authorization_code grant type', async () => {
+        const client = new NodeHiveClient({
+            baseUrl: 'https://idp.example.com',
+            auth: {
+                method: 'oauth',
+                oauth: {
+                    grantType: 'authorization_code',
+                    clientId: 'frontends',
+                    clientSecret: 'secret',
+                    authorizeUrl: 'https://idp.example.com/oauth/authorize',
+                    redirectUri: 'https://app.example.com/api/auth/callback'
+                }
+            }
+        });
+        helper.assert(client.auth.isAuthorizationCodeGrant(), 'isAuthorizationCodeGrant() true');
+        helper.assert(client.auth.strategy instanceof OAuthAuthorizationCodeStrategy, 'Strategy is OAuthAuthorizationCodeStrategy');
+        helper.debug('AuthManager picks AuthorizationCode strategy');
+    });
+
+    await helper.test('exchangeCode persists tokens + fetches user details', async () => {
+        const ACCESS = makeJwt({ sub: '42' });
+        const calls = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async (url, init) => {
+            calls.push({ url: String(url), init });
+            if (String(url).endsWith('/oauth/token')) {
+                return mockJson({
+                    access_token: ACCESS,
+                    refresh_token: 'REFRESH-1',
+                    token_type: 'Bearer',
+                    expires_in: 900
+                });
+            }
+            if (String(url).includes('/user/42')) {
+                return mockJson({
+                    uid: [{ value: 42 }],
+                    name: [{ value: 'Yannick' }],
+                    roles: [{ target_id: 'editor' }, { target_id: 'authenticated' }]
+                });
+            }
+            throw new Error('Unexpected fetch: ' + url);
+        };
+
+        try {
+            const client = new NodeHiveClient({
+                baseUrl: 'https://idp.example.com',
+                auth: {
+                    method: 'oauth',
+                    oauth: {
+                        grantType: 'authorization_code',
+                        clientId: 'frontends',
+                        clientSecret: 'secret'
+                    }
+                }
+            });
+
+            const result = await client.auth.exchangeCode({
+                code: 'CODE-xyz',
+                codeVerifier: 'VERIFIER-xyz',
+                redirectUri: 'https://app.example.com/api/auth/callback'
+            });
+
+            helper.assert(result.success, 'exchangeCode reports success');
+            helper.assert(result.token === ACCESS, 'access token returned');
+            helper.assert(result.refresh_token === 'REFRESH-1', 'refresh token returned');
+            helper.assert(result.user?.roles?.[0]?.target_id === 'editor', 'roles parsed from user details');
+
+            const storedToken = await client.auth.getToken();
+            const storedRefresh = await client.auth.getRefreshToken();
+            const storedUser = await client.auth.getUserDetails();
+            helper.assert(storedToken === ACCESS, 'access token persisted in storage');
+            helper.assert(storedRefresh === 'REFRESH-1', 'refresh token persisted in storage');
+            helper.assert(storedUser?.name?.[0]?.value === 'Yannick', 'user_details persisted');
+
+            const tokenCall = calls.find(c => c.url.endsWith('/oauth/token'));
+            const body = new URLSearchParams(tokenCall.init.body);
+            helper.assert(body.get('grant_type') === 'authorization_code', 'grant_type=authorization_code');
+            helper.assert(body.get('code') === 'CODE-xyz', 'code forwarded');
+            helper.assert(body.get('code_verifier') === 'VERIFIER-xyz', 'code_verifier forwarded');
+            helper.assert(body.get('redirect_uri') === 'https://app.example.com/api/auth/callback', 'redirect_uri forwarded');
+            helper.assert(body.get('client_id') === 'frontends', 'client_id forwarded');
+            helper.assert(body.get('client_secret') === 'secret', 'client_secret forwarded');
+            helper.debug('exchangeCode integration verified');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    await helper.test('exchangeCode falls back to configured redirectUri', async () => {
+        const ACCESS = makeJwt({ sub: '42' });
+        const calls = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async (url, init) => {
+            calls.push({ url: String(url), init });
+            if (String(url).endsWith('/oauth/token')) {
+                return mockJson({ access_token: ACCESS, token_type: 'Bearer', expires_in: 900 });
+            }
+            if (String(url).includes('/user/42')) {
+                return mockJson({ uid: [{ value: 42 }], roles: [] });
+            }
+            throw new Error('Unexpected fetch: ' + url);
+        };
+
+        try {
+            const client = new NodeHiveClient({
+                baseUrl: 'https://idp.example.com',
+                auth: {
+                    method: 'oauth',
+                    oauth: {
+                        grantType: 'authorization_code',
+                        clientId: 'frontends',
+                        clientSecret: 'secret',
+                        redirectUri: 'https://app.example.com/api/auth/callback'
+                    }
+                }
+            });
+
+            // No per-call redirectUri — must fall back to oauthConfig.redirectUri
+            await client.auth.exchangeCode({ code: 'CODE', codeVerifier: 'V' });
+
+            const tokenCall = calls.find(c => c.url.endsWith('/oauth/token'));
+            const body = new URLSearchParams(tokenCall.init.body);
+            helper.assert(
+                body.get('redirect_uri') === 'https://app.example.com/api/auth/callback',
+                'redirect_uri taken from oauthConfig when not passed per call'
+            );
+            helper.debug('configured redirectUri fallback verified');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    await helper.test('refreshToken rotates tokens and updates user details', async () => {
+        const ACCESS_2 = makeJwt({ sub: '42' });
+        const calls = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async (url, init) => {
+            calls.push({ url: String(url), init });
+            if (String(url).endsWith('/oauth/token')) {
+                return mockJson({
+                    access_token: ACCESS_2,
+                    refresh_token: 'REFRESH-2',
+                    token_type: 'Bearer',
+                    expires_in: 900
+                });
+            }
+            if (String(url).includes('/user/42')) {
+                return mockJson({ uid: [{ value: 42 }], roles: [{ target_id: 'admin' }] });
+            }
+            throw new Error('Unexpected fetch: ' + url);
+        };
+
+        try {
+            const client = new NodeHiveClient({
+                baseUrl: 'https://idp.example.com',
+                auth: {
+                    method: 'oauth',
+                    oauth: {
+                        grantType: 'authorization_code',
+                        clientId: 'frontends',
+                        clientSecret: 'secret'
+                    }
+                }
+            });
+            await client.auth.setRefreshToken('REFRESH-1');
+
+            const result = await client.auth.refreshToken();
+
+            helper.assert(result.success, 'refresh reports success');
+            helper.assert(result.token === ACCESS_2, 'rotated access token returned');
+            helper.assert(result.refresh_token === 'REFRESH-2', 'rotated refresh token returned');
+            helper.assert(result.user?.roles?.[0]?.target_id === 'admin', 'user_details refreshed with new roles');
+
+            const body = new URLSearchParams(calls[0].init.body);
+            helper.assert(body.get('grant_type') === 'refresh_token', 'grant_type=refresh_token');
+            helper.assert(body.get('refresh_token') === 'REFRESH-1', 'old refresh token sent');
+            helper.debug('refreshToken rotation verified');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    await helper.test('exchangeCode surfaces Drupal error responses', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async () => mockJson({ error: 'invalid_grant', error_description: 'Invalid auth code' }, 400);
+
+        try {
+            const client = new NodeHiveClient({
+                baseUrl: 'https://idp.example.com',
+                auth: {
+                    method: 'oauth',
+                    oauth: {
+                        grantType: 'authorization_code',
+                        clientId: 'frontends',
+                        clientSecret: 'secret'
+                    }
+                }
+            });
+            let threw = false;
+            try {
+                await client.auth.exchangeCode({
+                    code: 'BAD',
+                    codeVerifier: 'V',
+                    redirectUri: 'https://app.example.com/api/auth/callback'
+                });
+            } catch (e) {
+                threw = true;
+                helper.assert(/Invalid auth code/.test(e.message), 'error_description surfaced in error message');
+            }
+            helper.assert(threw, 'exchangeCode throws on 4xx');
+            helper.debug('exchangeCode error path verified');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
     await helper.summary();
+}
+
+function makeJwt(payload) {
+    const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64')
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const body = Buffer.from(JSON.stringify(payload)).toString('base64')
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    return `${header}.${body}.signature`;
+}
+
+function mockJson(body, status = 200) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body
+    };
 }
 
 // Run tests

--- a/package/types.d.ts
+++ b/package/types.d.ts
@@ -119,6 +119,11 @@ export class AuthManager {
     login(username?: string, password?: string, options?: LoginOptions): Promise<LoginResult>;
 
     /**
+     * Exchange an OAuth authorization code for tokens (Authorization Code + PKCE flow)
+     */
+    exchangeCode(options: ExchangeCodeOptions): Promise<LoginResult>;
+
+    /**
      * Refresh the current access token (if supported by the strategy)
      */
     refreshToken(options?: LoginOptions): Promise<LoginResult>;
@@ -161,6 +166,8 @@ export class AuthManager {
     decodeJwt(token: string): any;
 
     isClientCredentialsGrant(): boolean;
+
+    isAuthorizationCodeGrant(): boolean;
 
     resolveMaxAge(...candidates: Array<number | string | null | undefined>): number | null;
 }
@@ -257,8 +264,9 @@ export interface OAuthConfig {
      * OAuth grant type
      * - 'password': User authentication with username/password
      * - 'client_credentials': Service account / server-to-server
+     * - 'authorization_code': Authorization Code Flow with PKCE (SSO via IdP redirect)
      */
-    grantType?: 'password' | 'client_credentials';
+    grantType?: 'password' | 'client_credentials' | 'authorization_code';
 
     /**
      * OAuth client ID
@@ -274,6 +282,23 @@ export interface OAuthConfig {
      * OAuth scope (optional)
      */
     scope?: string;
+
+    /**
+     * Authorize endpoint URL (Authorization Code flow only).
+     * Example: https://idp.example.com/oauth/authorize
+     */
+    authorizeUrl?: string;
+
+    /**
+     * Token endpoint URL. Defaults to `{baseUrl}/oauth/token` when omitted.
+     */
+    tokenUrl?: string;
+
+    /**
+     * Default redirect URI for Authorization Code flow. Can be overridden per call
+     * (e.g. for multi-domain deployments where the redirect_uri is derived per request).
+     */
+    redirectUri?: string;
 }
 
 /**
@@ -283,7 +308,7 @@ export interface LoginOptions {
     /**
      * OAuth grant type override
      */
-    grantType?: 'password' | 'client_credentials';
+    grantType?: 'password' | 'client_credentials' | 'authorization_code';
 
     /**
      * OAuth client ID override
@@ -309,6 +334,68 @@ export interface LoginOptions {
      * Override for refresh token max-age persistence (seconds)
      */
     refreshTokenMaxAge?: number;
+}
+
+/**
+ * Options for AuthManager.exchangeCode (Authorization Code + PKCE flow)
+ */
+export interface ExchangeCodeOptions extends LoginOptions {
+    /** Authorization code from the OAuth callback */
+    code: string;
+    /** PKCE code_verifier matching the code_challenge sent to /oauth/authorize */
+    codeVerifier: string;
+    /** Redirect URI used for the original /oauth/authorize request (must match exactly) */
+    redirectUri: string;
+}
+
+/**
+ * PKCE primitives for the OAuth 2.0 Authorization Code + PKCE flow.
+ */
+export interface PKCEPair {
+    codeVerifier: string;
+    codeChallenge: string;
+    codeChallengeMethod: 'S256';
+}
+
+/**
+ * Generate a PKCE code_verifier/code_challenge pair using crypto.subtle.
+ * Works in both Node (>= 16) and modern browsers.
+ */
+export function generatePKCE(): Promise<PKCEPair>;
+
+/**
+ * Generate a random `state` parameter for the OAuth Authorization Request.
+ * Returns 32 random bytes encoded as base64url.
+ */
+export function generateState(): string;
+
+/**
+ * Options for buildAuthorizeUrl.
+ */
+export interface BuildAuthorizeUrlOptions {
+    authorizeUrl: string;
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    codeChallenge: string;
+    scope?: string;
+    codeChallengeMethod?: 'S256';
+}
+
+/**
+ * Build the /oauth/authorize URL for an OAuth Authorization Code + PKCE redirect.
+ */
+export function buildAuthorizeUrl(options: BuildAuthorizeUrlOptions): string;
+
+/**
+ * OAuth 2.0 Authorization Code + PKCE strategy.
+ * Use via AuthManager when oauthConfig.grantType === 'authorization_code'.
+ */
+export class OAuthAuthorizationCodeStrategy {
+    constructor(authManager: AuthManager);
+    exchangeCode(options: ExchangeCodeOptions): Promise<LoginResult>;
+    refreshToken(options?: LoginOptions): Promise<LoginResult>;
+    fetchUserDetails(token: string): Promise<any>;
 }
 
 export interface StorageOptions {
@@ -560,6 +647,13 @@ declare module 'nodehive-js' {
         AuthOptions,
         OAuthConfig,
         LoginOptions,
+        ExchangeCodeOptions,
+        OAuthAuthorizationCodeStrategy,
+        PKCEPair,
+        BuildAuthorizeUrlOptions,
+        generatePKCE,
+        generateState,
+        buildAuthorizeUrl,
         StorageAdapter,
         MemoryStorage,
         BrowserStorage,


### PR DESCRIPTION
## Summary

Adds the OAuth 2.0 **Authorization Code flow with PKCE** to nodehive-js, enabling SSO setups where Drupal acts as the central Identity Provider. This is the SDK half of the NodeHive starter's migration away from the (OAuth 2.1-deprecated) Password Grant.

Role/permission handling stays functionally identical to the Password Grant flow — user details (incl. the roles array) are still fetched from `/user/{uid}` after login and refresh.

## What's included

- **`OAuthAuthorizationCodeStrategy`** — full auth-code grant strategy (169 lines)
- **PKCE helpers** (`oauth/pkce.js`) — verifier/challenge generation
- **`authorize-url.js`** — builds the Drupal authorization redirect URL
- **`helpers/user-details.js`** — shared user-details fetch (roles parsing), reused by both Password and Authorization-Code strategies
- **`AuthManager`** wiring + **`types.d.ts`** updates + **`OAUTH_AUTHENTICATION.md`** docs
- **Tests** — +308 lines: PKCE verifier/challenge roundtrip, authorize-URL builder, code-exchange mock, refresh rotation, user-details/roles parsing
- Version bump to `2.0.0-beta.13` + CHANGELOG entry

## Release

After merge, publish per `RELEASING.md` as a **beta** (`v2.0.0-beta.13`, beta dist-tag) via the OIDC publish workflow.

Roadmap: https://my.netnode.ch/workspace/79/roadmap/1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)