### PR TITLE
fix(client): don't parse body on 204/205 responses

### DIFF
--- a/package/src/NodeHiveClient.js
+++ b/package/src/NodeHiveClient.js
@@ -333,7 +333,10 @@ export class NodeHiveClient {
                 throw error;
             }
 
-            let responseData = await response.json();
+            let responseData =
+                response.status === 204 || response.status === 205
+                    ? null
+                    : await response.json();
 
             // Apply response interceptors
             if (!skipInterceptors) {

--- a/package/tests/public-api.test.js
+++ b/package/tests/public-api.test.js
@@ -40,6 +40,25 @@ export async function runTests() {
         helper.assert(response.data.value === 42, 'raw data should be preserved');
     });
 
+    await helper.test('client.request() returns null for empty-body statuses (204/205)', async () => {
+        for (const status of [204, 205]) {
+            mockFetch({
+                ok: true,
+                status,
+                statusText: 'No Content',
+                json: async () => {
+                    throw new Error('Unexpected end of JSON input');
+                },
+            });
+
+            const response = await createClient().request('/jsonapi/node/page/123', {
+                method: 'DELETE',
+            });
+
+            helper.assert(response === null, `${status} response should resolve to null`);
+        }
+    });
+
     helper.section('Helper unwrapping');
 
     await helper.test('getApiIndex() unwraps a successful envelope', async () => {


### PR DESCRIPTION
## Problem

`request()` calls `response.json()` unconditionally. But `204 No Content` and `205 Reset Content` responses carry **no body** per the HTTP spec (RFC 9110), and JSON:API returns `204` on a successful `DELETE`. Parsing an empty body throws `SyntaxError: Unexpected end of JSON input`, which the client wraps into a `NetworkError` — so every successful `DELETE` (and any 204/205) surfaces as a failure even though the request worked.

## Fix

Skip parsing for empty-body statuses and return `null` instead:

```js
let responseData =
    response.status === 204 || response.status === 205
        ? null
        : await response.json();
```

This is the standard approach recommended by the WHATWG Fetch maintainers (`.json()` intentionally throws on an empty body; clients must check the status) and mirrors how axios treats 204 (`data` is empty rather than a parse error).

Non-2xx statuses (incl. 304) are already handled earlier by the `!response.ok` branch, so they never reach this line.

## Test

Added a unit test in `package/tests/public-api.test.js`: `client.request()` returns `null` for 204/205 (mock `json()` throws to prove it is never called). All 7 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)